### PR TITLE
Use `multiline=True` for regex

### DIFF
--- a/roles/ntp/tasks/ios.yaml
+++ b/roles/ntp/tasks/ios.yaml
@@ -6,7 +6,7 @@
   register: config
 
 - name: get current configured ntp servers
-  set_fact: _servers="{{ config.stdout[0] | regex_findall('^ntp server (\S+)') }}"
+  set_fact: _servers="{{ config.stdout[0] | regex_findall('^ntp server (\S+)', multiline=True) }}"
 
 - name: remove old ntp servers
   ios_config:


### PR DESCRIPTION
The current regex won't match properly. It either needs `^` removed, or `multiline=True` added.